### PR TITLE
Add some mouse tracking. 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
 (defproject flocking "1.0.0-SNAPSHOT"
   :description "FIXME: write description"
-  :dependencies [[org.clojure/clojure "1.3.0"]
+  :dependencies [[org.clojure/clojure "1.4.0"]
                  [quil "1.4.1"]])

--- a/src/flocking/core.clj
+++ b/src/flocking/core.clj
@@ -4,7 +4,9 @@
 (def NUM-BOIDS 10)
 (def CANVAS 800)
 (def INIT-SPEED 2)
-(def COHESION 0.01)
+(def COHESION 0.001)
+(def ALIGN 0.1)
+(def MAX_SPEED 5)
 
 (defn make-boid
   []
@@ -16,19 +18,31 @@
 (defn setup []
   (smooth)
   (frame-rate 30)
-  (set-state! :boids (atom (take NUM-BOIDS (repeatedly make-boid))))
+  (set-state!   :mousepos (atom [(/ CANVAS 2) (/ CANVAS 2)])
+                :boids (atom (take NUM-BOIDS (repeatedly make-boid))))
   (background 200))
+  
+(defn bound
+    [val]
+    (if (> val MAX_SPEED) MAX_SPEED (if (< val (- MAX_SPEED)) (- MAX_SPEED) val)))
 
 (defn update-boids
   [boids]
-  (let [avg-x 400 ;(/ (reduce + (map :x boids)) NUM-BOIDS)
-        avg-y 400] ;(/ (reduce + (map :y boids)) NUM-BOIDS)]
+  (let [avg-x (/ (reduce + (map :x boids)) NUM-BOIDS)
+        avg-y (/ (reduce + (map :y boids)) NUM-BOIDS)
+        avg-dx (/ (reduce + (map :dx boids)) NUM-BOIDS)
+        avg-dy (/ (reduce + (map :dy boids)) NUM-BOIDS)
+        ]
     (doall
       (for [{:keys [x y dx dy] :as b} boids]
         (let [c-dx (* (- avg-x x) COHESION)
               c-dy (* (- avg-y y) COHESION)
-              dx   (+ dx c-dx)
-              dy   (+ dy c-dy)]
+              a-dx (* (- avg-dx dx) ALIGN)
+              a-dy (* (- avg-dy dy) ALIGN)
+              m-dx (-> @(state :mousepos) (first) (- x) (* COHESION))
+              m-dy (-> @(state :mousepos) (second) (- y) (* COHESION))
+              dx   (bound (+ dx c-dx m-dx))
+              dy   (bound (+ dy c-dy m-dy))]
         (assoc b
                :x (mod (+ x dx) CANVAS)
                :y (mod (+ y dy) CANVAS)
@@ -43,9 +57,14 @@
   (doseq [{:keys [x y]} @(state :boids)]
     (triangle x y (+ x 10) (+ y 10) (+ x 10) (- y 10))))
 
+(defn mouse-moved []
+    (let [  x (mouse-x)
+            y (mouse-y)]
+            (reset! (state :mousepos) [x y])))
 
 (defsketch example
   :title "Flocking"
   :setup setup
+  :mouse-moved mouse-moved
   :draw draw :size [CANVAS CANVAS])
 


### PR DESCRIPTION
Adding in a couple of small features. Firstly, had to bump to clj 1.4.0 in order to get the mouse stuff working with this version of Quil. Then added a mouse update callback (:mouse-moved in the sketch) and included that in the update loop for the boids. The mouse position is stored in the canvas state as an atom, along with the boids.

The mouse pos is just subtracked from the current pos, and the whole direction is multiplied by the cohesion value so that the boids just drift that way. Note you have to click before the applet tracks the mouse.

I also reinstated the cohesion average, and added a bound function that just clips the speed to stop the boids getting ot of control. Haven't done the avoid function yet.
